### PR TITLE
Set state to started rather than running

### DIFF
--- a/devbox_build/roles/docker/tasks/docker.yml
+++ b/devbox_build/roles/docker/tasks/docker.yml
@@ -14,7 +14,7 @@
 
 - name: start docker
   become: yes
-  service: name=docker state=running enabled=yes
+  service: name=docker state=started enabled=yes
 
 - name: enable docker to start automatically
   become: yes


### PR DESCRIPTION
In testing this role, it seemed like Ansible didn't like "running" as a state, so I changed it to "started" as that was one of the options from this message: 

```
TASK [docker : start docker] ******************************************************
fatal: [10.10.20.20]: FAILED! => {"changed": false, "msg": "value of state must be one of: reloaded, restarted, started, stopped, got: running"}
```